### PR TITLE
feat: Simple HTTP server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build-linux:
+	mkdir -p bin
+	GOOS=linux GOARCH=arm64 go build -o bin/pos-linux main.go
+
+clean-linux:
+	rm -rf bin/pos-linux

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ func runRootCommand(cmd *cobra.Command, args []string) error {
 	p.Log("Hello, world!")
 	p.Feed(3)
 	p.SimpleLine()
-	p.Cut()
+	p.FeedAndCut(3)
 	p.Flush()
 	return nil
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -118,8 +119,15 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 			return
 		}
 
+		bytes, err := p.Flush()
+		if err != nil {
+			log.Printf("printer flush error: %v", err)
+			http.Error(w, "Failed to send cut command to printer", http.StatusInternalServerError)
+			return
+		}
+
 		w.WriteHeader(http.StatusAccepted)
-		w.Write([]byte("Cut command sent to printer"))
+		fmt.Fprintf(w, "Cut command sent to printer: %v", bytes)
 	})
 
 	log.Println("Starting server on :42069")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -76,7 +76,7 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 
 		p.WriteString(text)
 		// Feed a couple lines to push content out of the head area
-		p.FeedAndCut(5)
+		p.FeedAndCut(10)
 
 		if _, err := p.Flush(); err != nil {
 			log.Printf("flush error: %v", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"log"
 	"net/http"
-    "strings"
-    "sync"
+	"strings"
+	"sync"
 
 	"github.com/connordoman/pos/internal/escpos"
 	"github.com/go-chi/chi"
@@ -76,7 +76,7 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 
 		p.WriteString(text)
 		// Feed a couple lines to push content out of the head area
-		p.Feed(2)
+		p.FeedAndCut(5)
 
 		if _, err := p.Flush(); err != nil {
 			log.Printf("flush error: %v", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -181,6 +181,7 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 
 		if err := p.FeedAndCut(5); err != nil {
 			log.Printf("printer feed and cut error: %v", err)
+			log.Printf("original message: %s", text)
 			http.Error(w, "Failed to feed and cut paper", http.StatusInternalServerError)
 			return
 		}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -76,7 +76,8 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 
 		p.WriteString(text)
 		// Feed a couple lines to push content out of the head area
-		p.FeedAndCut(10)
+		// p.FeedAndCut(10)
+		p.WriteString("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
 
 		if _, err := p.Flush(); err != nil {
 			log.Printf("flush error: %v", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -56,5 +56,9 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 		p.Flush()
 	})
 
+	p.Log("Starting server on :42069")
+	p.Cut()
+	p.Flush()
+
 	return http.ListenAndServe(":42069", r)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -173,6 +173,7 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 		markdown, err := md.Parse(text)
 		if err != nil {
 			log.Printf("markdown parse error: %v", err)
+			log.Printf("original message: %s", text)
 			http.Error(w, "Failed to parse markdown", http.StatusBadRequest)
 			return
 		}
@@ -181,7 +182,6 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 
 		if err := p.FeedAndCut(5); err != nil {
 			log.Printf("printer feed and cut error: %v", err)
-			log.Printf("original message: %s", text)
 			http.Error(w, "Failed to feed and cut paper", http.StatusInternalServerError)
 			return
 		}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -88,5 +88,7 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 		w.Write([]byte("Print job queued to device"))
 	})
 
+	log.Println("Starting server on :42069")
+
 	return http.ListenAndServe(":42069", r)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -192,7 +192,11 @@ func runServeCommand(cmd *cobra.Command, args []string) error {
 			return
 		}
 
-		log.Printf("Sent %d bytes to printer", b)
+		msg := fmt.Sprintf("Print job queued to device (%d bytes)", b)
+
+		log.Println(msg)
+
+		w.Write([]byte(msg))
 
 	})
 

--- a/internal/escpos/fmt.go
+++ b/internal/escpos/fmt.go
@@ -1,0 +1,17 @@
+package escpos
+
+func (p *Printer) Emphasize(on bool) {
+	if on {
+		p.Write([]byte{0x1B, 0x45, 1})
+	} else {
+		p.Write([]byte{0x1B, 0x45, 0})
+	}
+}
+
+func (p *Printer) DoubleStrike(on bool) {
+	if on {
+		p.Write([]byte{0x1B, 0x47, 1})
+	} else {
+		p.Write([]byte{0x1B, 0x47, 0})
+	}
+}

--- a/internal/escpos/fmt.go
+++ b/internal/escpos/fmt.go
@@ -1,17 +1,32 @@
 package escpos
 
+const (
+	CharEscape       = 0x1B
+	CharBold         = 0x45
+	CharDoubleStrike = 0x47
+	CharUnderline    = 0x2D
+)
+
 func (p *Printer) Emphasize(on bool) {
 	if on {
-		p.Write([]byte{0x1B, 0x45, 1})
+		p.Write([]byte{CharEscape, CharBold, 1})
 	} else {
-		p.Write([]byte{0x1B, 0x45, 0})
+		p.Write([]byte{CharEscape, CharBold, 0})
 	}
 }
 
 func (p *Printer) DoubleStrike(on bool) {
 	if on {
-		p.Write([]byte{0x1B, 0x47, 1})
+		p.Write([]byte{CharEscape, CharDoubleStrike, 1})
 	} else {
-		p.Write([]byte{0x1B, 0x47, 0})
+		p.Write([]byte{CharEscape, CharDoubleStrike, 0})
+	}
+}
+
+func (p *Printer) Underline(on bool) {
+	if on {
+		p.Write([]byte{CharEscape, CharUnderline, 1})
+	} else {
+		p.Write([]byte{CharEscape, CharUnderline, 0})
 	}
 }

--- a/internal/escpos/select_cut.go
+++ b/internal/escpos/select_cut.go
@@ -56,11 +56,11 @@ func (p *Printer) SelectCutModeAndCut(function rune, m, n byte) error {
 }
 
 func (p *Printer) Cut() error {
-	return p.SelectCutModeAndCut('A', AFullCut0, 0)
+	return p.SelectCutModeAndCut('A', AFullCut, 0)
 }
 
 func (p *Printer) CutPartial() error {
-	return p.SelectCutModeAndCut('A', APartialCut0, 0)
+	return p.SelectCutModeAndCut('A', APartialCut, 0)
 }
 
 func (p *Printer) FeedAndCut(lines uint8) error {

--- a/internal/escpos/select_cut.go
+++ b/internal/escpos/select_cut.go
@@ -25,7 +25,7 @@ func (p *Printer) SelectCutModeAndCut(function rune, m, n byte) error {
 	bytes := []byte{0x1D, 0x56}
 	switch function {
 	case 'A':
-		if m != AFullCut && m != AFullCut0 || m != APartialCut && m != APartialCut0 {
+		if m != AFullCut && m != AFullCut0 && m != APartialCut && m != APartialCut0 {
 			return errors.New("invalid cut mode for function A")
 		}
 		bytes = append(bytes, m)

--- a/internal/escpos/select_cut.go
+++ b/internal/escpos/select_cut.go
@@ -64,7 +64,7 @@ func (p *Printer) CutPartial() error {
 }
 
 func (p *Printer) FeedAndCut(lines uint8) error {
-	lines *= 15             // each line is approx 15 turn units
+	lines *= 23             // each line is approx 23 turn units
 	lines = min(lines, 254) // 255 is an overflow
 	return p.SelectCutModeAndCut('B', BFullCut, lines)
 }

--- a/internal/escpos/select_cut.go
+++ b/internal/escpos/select_cut.go
@@ -64,6 +64,7 @@ func (p *Printer) CutPartial() error {
 }
 
 func (p *Printer) FeedAndCut(lines uint8) error {
+	lines *= 15             // each line is approx 15 turn units
 	lines = min(lines, 254) // 255 is an overflow
 	return p.SelectCutModeAndCut('B', BFullCut, lines)
 }

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -17,12 +17,15 @@ func Parse(text string) ([]byte, error) {
 	for i := 0; i < len(text); i++ {
 		c := text[i]
 
+		nextIndex := min(i+1, len(text)-1)
+		nextNextIndex := min(i+2, len(text)-1)
+
 		switch c {
 		case ' ':
 			bytes = append(bytes, c)
 
-			nextC := text[min(i+1, len(text)-1)]
-			nextNextC := text[min(i+2, len(text)-1)]
+			nextC := text[nextIndex]
+			nextNextC := text[nextNextIndex]
 			if nextC == '*' && nextNextC == '*' {
 				boldCounter++
 				bytes = append(bytes, escape, bold, 1)
@@ -34,16 +37,22 @@ func Parse(text string) ([]byte, error) {
 			}
 
 		case '*':
-			nextC := text[min(i+1, len(text)-1)]
-			nextNextC := text[min(i+2, len(text)-1)]
+			nextC := text[nextIndex]
+			nextNextC := text[nextNextIndex]
+			if nextIndex == nextNextIndex {
+				nextNextC = 0x00
+			}
 			if nextC == '*' && (nextNextC == ' ' || nextNextC == 0x00) {
 				boldCounter--
 				bytes = append(bytes, escape, bold, 0)
 				i += 1
 			}
 		case '_':
-			nextC := text[min(i+1, len(text)-1)]
-			nextNextC := text[min(i+2, len(text)-1)]
+			nextC := text[nextIndex]
+			nextNextC := text[nextNextIndex]
+			if nextIndex == nextNextIndex {
+				nextNextC = 0x00
+			}
 			if nextC == '_' && (nextNextC == ' ' || nextNextC == 0x00) {
 				doubleStrikeCounter--
 				bytes = append(bytes, escape, doubleStrike, 0)

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -36,7 +36,7 @@ func Parse(text string) ([]byte, error) {
 		case '*':
 			nextC := text[min(i+1, len(text)-1)]
 			nextNextC := text[min(i+2, len(text)-1)]
-			if nextC == '*' && nextNextC == ' ' {
+			if nextC == '*' && (nextNextC == ' ' || nextNextC == 0x00) {
 				boldCounter--
 				bytes = append(bytes, escape, bold, 0)
 				i += 1
@@ -44,7 +44,7 @@ func Parse(text string) ([]byte, error) {
 		case '_':
 			nextC := text[min(i+1, len(text)-1)]
 			nextNextC := text[min(i+2, len(text)-1)]
-			if nextC == '_' && nextNextC == ' ' {
+			if nextC == '_' && (nextNextC == ' ' || nextNextC == 0x00) {
 				doubleStrikeCounter--
 				bytes = append(bytes, escape, doubleStrike, 0)
 				i += 1

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -1,0 +1,65 @@
+package md
+
+import "fmt"
+
+const (
+	escape       = 0x1B
+	bold         = 0x45
+	doubleStrike = 0x47
+)
+
+func Parse(text string) ([]byte, error) {
+	bytes := []byte{}
+
+	boldCounter := 0
+	doubleStrikeCounter := 0
+
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+
+		switch c {
+		case ' ':
+			bytes = append(bytes, c)
+
+			nextC := text[min(i+1, len(text)-1)]
+			nextNextC := text[min(i+2, len(text)-1)]
+			if nextC == '*' && nextNextC == '*' {
+				boldCounter++
+				bytes = append(bytes, escape, bold, 1)
+				i += 1
+			} else if nextC == '_' && nextNextC == '_' {
+				doubleStrikeCounter++
+				bytes = append(bytes, escape, doubleStrike, 1)
+				i += 1
+			}
+
+		case '*':
+			nextC := text[min(i+1, len(text)-1)]
+			nextNextC := text[min(i+2, len(text)-1)]
+			if nextC == '*' && nextNextC == ' ' {
+				doubleStrikeCounter--
+				bytes = append(bytes, escape, doubleStrike, 0)
+				i += 1
+			}
+		case '_':
+			nextC := text[min(i+1, len(text)-1)]
+			nextNextC := text[min(i+2, len(text)-1)]
+			if nextC == '_' && nextNextC == ' ' {
+				doubleStrikeCounter--
+				bytes = append(bytes, escape, doubleStrike, 0)
+				i += 1
+			}
+		}
+
+	}
+
+	if boldCounter != 0 {
+		return nil, fmt.Errorf("unmatched bold markers")
+	}
+
+	if doubleStrikeCounter != 0 {
+		return nil, fmt.Errorf("unmatched double strike markers")
+	}
+
+	return bytes, nil
+}

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -1,6 +1,9 @@
 package md
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+)
 
 const (
 	escape       = 0x1B
@@ -19,6 +22,8 @@ func Parse(text string) ([]byte, error) {
 
 		nextIndex := min(i+1, len(text)-1)
 		nextNextIndex := min(i+2, len(text)-1)
+
+		fmt.Printf("%c", c)
 
 		switch c {
 		case ' ':
@@ -63,6 +68,8 @@ func Parse(text string) ([]byte, error) {
 		}
 
 	}
+
+	log.Printf("boldCounter: %d, doubleStrikeCounter: %d", boldCounter, doubleStrikeCounter)
 
 	if boldCounter != 0 {
 		return nil, fmt.Errorf("unmatched bold markers")

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -34,11 +34,11 @@ func Parse(text string) ([]byte, error) {
 			if nextC == '*' && nextNextC == '*' {
 				boldCounter++
 				bytes = append(bytes, escape, bold, 1)
-				i += 1
+				i += 2
 			} else if nextC == '_' && nextNextC == '_' {
 				doubleStrikeCounter++
 				bytes = append(bytes, escape, doubleStrike, 1)
-				i += 1
+				i += 2
 			}
 
 		case '*':
@@ -49,7 +49,7 @@ func Parse(text string) ([]byte, error) {
 			}
 
 			fmt.Printf("\nis * nextC: `%c` nextNextC: `%c`\n", nextC, nextNextC)
-			if nextC == '*' && (nextNextC == ' ' || nextNextC == 0x00) {
+			if nextC == '*' && (nextNextC == '\n' || nextNextC == ' ' || nextNextC == 0x00) {
 				boldCounter--
 				bytes = append(bytes, escape, bold, 0)
 				i += 1
@@ -60,7 +60,7 @@ func Parse(text string) ([]byte, error) {
 			if nextIndex == nextNextIndex {
 				nextNextC = 0x00
 			}
-			if nextC == '_' && (nextNextC == ' ' || nextNextC == 0x00) {
+			if nextC == '_' && (nextNextC == '\n' || nextNextC == ' ' || nextNextC == 0x00) {
 				doubleStrikeCounter--
 				bytes = append(bytes, escape, doubleStrike, 0)
 				i += 1

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -42,7 +42,7 @@ func Parse(text string) ([]byte, error) {
 			}
 
 		case '*':
-			if doubleStrikeCounter == 0 {
+			if boldCounter == 0 {
 				bytes = append(bytes, c)
 				continue
 			}

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -58,6 +58,8 @@ func Parse(text string) ([]byte, error) {
 				bytes = append(bytes, escape, doubleStrike, 0)
 				i += 1
 			}
+		default:
+			bytes = append(bytes, c)
 		}
 
 	}

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -37,8 +37,8 @@ func Parse(text string) ([]byte, error) {
 			nextC := text[min(i+1, len(text)-1)]
 			nextNextC := text[min(i+2, len(text)-1)]
 			if nextC == '*' && nextNextC == ' ' {
-				doubleStrikeCounter--
-				bytes = append(bytes, escape, doubleStrike, 0)
+				boldCounter--
+				bytes = append(bytes, escape, bold, 0)
 				i += 1
 			}
 		case '_':

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -48,7 +48,7 @@ func Parse(text string) ([]byte, error) {
 				nextNextC = 0x00
 			}
 
-			fmt.Printf("is *. nextC: %c, nextNextC: %c\n", nextC, nextNextC)
+			fmt.Printf("is *. nextC: %b, nextNextC: %b\n", nextC, nextNextC)
 			if nextC == '*' && (nextNextC == ' ' || nextNextC == 0x00) {
 				boldCounter--
 				bytes = append(bytes, escape, bold, 0)

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -48,7 +48,7 @@ func Parse(text string) ([]byte, error) {
 				nextNextC = 0x00
 			}
 
-			fmt.Printf("is *. nextC: %b, nextNextC: %b\n", nextC, nextNextC)
+			fmt.Printf("\nis * nextC: `%c` nextNextC: `%c`\n", nextC, nextNextC)
 			if nextC == '*' && (nextNextC == ' ' || nextNextC == 0x00) {
 				boldCounter--
 				bytes = append(bytes, escape, bold, 0)

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -47,6 +47,8 @@ func Parse(text string) ([]byte, error) {
 			if nextIndex == nextNextIndex {
 				nextNextC = 0x00
 			}
+
+			fmt.Printf("is *. nextC: %c, nextNextC: %c\n", nextC, nextNextC)
 			if nextC == '*' && (nextNextC == ' ' || nextNextC == 0x00) {
 				boldCounter--
 				bytes = append(bytes, escape, bold, 0)

--- a/internal/md/parser.go
+++ b/internal/md/parser.go
@@ -42,19 +42,27 @@ func Parse(text string) ([]byte, error) {
 			}
 
 		case '*':
+			if doubleStrikeCounter == 0 {
+				bytes = append(bytes, c)
+				continue
+			}
+
 			nextC := text[nextIndex]
 			nextNextC := text[nextNextIndex]
 			if nextIndex == nextNextIndex {
 				nextNextC = 0x00
 			}
-
-			fmt.Printf("\nis * nextC: `%c` nextNextC: `%c`\n", nextC, nextNextC)
 			if nextC == '*' && (nextNextC == '\n' || nextNextC == ' ' || nextNextC == 0x00) {
 				boldCounter--
 				bytes = append(bytes, escape, bold, 0)
 				i += 1
 			}
 		case '_':
+			if doubleStrikeCounter == 0 {
+				bytes = append(bytes, c)
+				continue
+			}
+
 			nextC := text[nextIndex]
 			nextNextC := text[nextNextIndex]
 			if nextIndex == nextNextIndex {


### PR DESCRIPTION
- **proper cut**
- **startup message**
- **short lived printer instance**
- **try fix printer not printing**
- **add cutting**
- **startup message**
- **feed lines instead of units**
- **10 lines comparison**
- **feat: /cut endpoint**
- **fix: better conditional**
- **change: naught for cut func A**
- **fix: flush cut command**
- **feat: change line printing ratio**
- **feat: simple markdown parser**
- **feat: simple markdown endpoint**
- **fix: bold/doublestrike mix up**
- **feat(dev): add original message logging**
- **fix: omg dumb**
- **change: add null char check**
- **change(md-parser): improve null check**
- **fix(parser): failed to add other chars**
- **feat(parser): add log statements**
- **feat(/print/markdown): pre-process body**
- **change: add debug statement for bold**
- **change: debug bold chars as bytes**
- **feat: improve bold error logs**
- **change: improve look-ahead**
- **fix: write underscores & asterisks for non-formatting**
- **fix: typo**
- **feat: convert to underline**
- **change: markdown endpoint response**
